### PR TITLE
Send JSON response with Headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ google_credentials.json
 backend-sa-key.json
 _NOTES.md
 documentation/build/
+.venv

--- a/query_api/main.py
+++ b/query_api/main.py
@@ -7,7 +7,7 @@ import requests
 import io
 import traceback
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import PlainTextResponse, HTMLResponse, Response
+from fastapi.responses import PlainTextResponse, HTMLResponse, JSONResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 from logger import logger
 from filters import parse_query_filters
@@ -108,7 +108,7 @@ def _process_api_query(request: Request, path: str) -> Union[List, Response]:
 
     # Return results
     if not use_csv:
-        return results
+        return JSONResponse(content=results, media_type="application/json; charset=utf-8")
     else:
         return _results_to_csv(
             results,

--- a/query_api/requirements.txt
+++ b/query_api/requirements.txt
@@ -5,3 +5,4 @@ pytest==7.4.2
 python-dateutil==2.8.2
 pytz==2023.3
 requests==2.31.0
+uvicorn[standard]==0.29.0


### PR DESCRIPTION
Fixes #11 

Send responses with the correct headers. Currently sending the header for `Content-Type` set to `application/json; charset=utf8`.