### PR TITLE
Fix: Handle duplicate MongoDB entries with upsert operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+openf1-venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
Description:**  
This PR modifies the MongoDB insertion logic to handle duplicate key errors gracefully by using `ReplaceOne` operations with `upsert=True` instead of `InsertOne`. 

Previously, when attempting to insert documents with IDs that already existed in the database, the system would fail with E11000 duplicate key errors. This caused issues when re-running data ingestion or when the data source contained duplicate entries.

The new approach:
- Replaces existing documents when the same ID is encountered
- Creates new documents when IDs don't yet exist
- Prevents duplicate key errors during bulk operations
- Maintains data consistency while allowing for re-runs of the ingestion process

These changes allow smoother operation in development environments and when processing historical data that may contain overlapping records.