### PR TITLE
fix(f1_scraping): normalize session names and types

### DIFF
--- a/src/openf1/services/f1_scraping/schedule.py
+++ b/src/openf1/services/f1_scraping/schedule.py
@@ -43,32 +43,22 @@ def _convert_gmt_offset(offset_str: str) -> str:
     return f"{cleaned_offset}:00"
 
 
-def _normalize_session_name(session_name: str) -> str:
+def _normalize_session_type_and_name(
+    session_type: str, session_name: str
+) -> tuple[str, str]:
     """
-    Replaces legacy session names with their modern equivalents.
-    If the session name is not a legacy name, returns the session name unmodified.
-    See https://docs.fastf1.dev/events.html#session-identifiers for background information.
-    """
-    match session_name:
-        case "Sprint Shootout":
-            return "Sprint Qualifying"
-        case _:
-            return session_name
-
-
-def _normalize_session_type(session_type: str) -> str:
-    """
-    Replaces legacy session types with more general types to be consistent with other sessions.
-    If the session type is not a legacy type, returns the session type unmodified.
+    Replaces legacy session types and names with their modern equivalents, if necessary.
     See https://docs.fastf1.dev/events.html#session-identifiers for background information.
     """
     match session_type:
         case "Sprint Shootout":
-            return "Qualifying"
+            # Normalizes pre-2024 "Sprint Qualifying" sessions
+            return "Qualifying", "Sprint Qualifying"
         case "Sprint Qualifying":
-            return "Race"
+            # Normalizes pre-2024 "Sprint" sessions
+            return "Race", "Sprint"
         case _:
-            return session_type
+            return session_type, session_name
 
 
 def get_meetings(year: int | None = None) -> list[dict]:
@@ -124,11 +114,15 @@ def get_sessions(year: int | None = None) -> list[dict]:
         timetable = _get_timetable(meeting["meeting_key"])
 
         for sess in timetable:
+            session_type, session_name = _normalize_session_type_and_name(
+                session_type=sess["sessionType"], session_name=sess["description"]
+            )
+
             sessions.append(
                 {
                     "session_key": sess["meetingSessionKey"],
-                    "session_type": _normalize_session_type(sess["sessionType"]),
-                    "session_name": _normalize_session_name(sess["description"]),
+                    "session_type": session_type,
+                    "session_name": session_name,
                     "date_start": _to_utc(sess["startTime"], meeting["gmt_offset"]),
                     "date_end": _to_utc(sess["endTime"], meeting["gmt_offset"]),
                     "meeting_key": meeting["meeting_key"],


### PR DESCRIPTION
Closes #303

## Description
This PR fixes a regression introduced by #299 by replacing legacy session names and types with their modern (2025 on) equivalents.

## Changes
- Add functions to normalize session names and types in the `schedule` service