### PR TITLE
feat: add team_colour to championship_teams

### DIFF
--- a/src/openf1/services/ingestor_livetiming/core/processing/collections/championship_teams.py
+++ b/src/openf1/services/ingestor_livetiming/core/processing/collections/championship_teams.py
@@ -14,6 +14,7 @@ class ChampionshipTeam(Document):
     session_key: int
     team_name: str
     _team_key: str
+    team_colour: str | None = None
     position_start: int | None = None
     position_current: int | None = None
     points_start: float | None = None
@@ -27,10 +28,26 @@ class ChampionshipTeam(Document):
 @dataclass
 class ChampionshipTeamCollection(Collection):
     name = "championship_teams"
-    source_topics = {"ChampionshipPrediction"}
+    source_topics = {"ChampionshipPrediction", "DriverList"}
     cache: dict = field(default_factory=dict)
+    team_colour_by_name: dict = field(default_factory=dict)
 
     def process_message(self, message: Message) -> Iterator[ChampionshipTeam]:
+        if message.topic == "DriverList":
+            for driver_data in message.content.values():
+                if not isinstance(driver_data, dict):
+                    continue
+                team_name = driver_data.get("TeamName")
+                team_colour = driver_data.get("TeamColour")
+                if team_name and team_colour:
+                    self.team_colour_by_name[team_name] = team_colour
+            # Back-fill teams already cached before DriverList arrived
+            for result in self.cache.values():
+                if result.team_colour is None and result.team_name in self.team_colour_by_name:
+                    result.team_colour = self.team_colour_by_name[result.team_name]
+                    yield result
+            return
+
         if "Teams" not in message.content:
             return
 
@@ -52,6 +69,9 @@ class ChampionshipTeamCollection(Collection):
                     team_name=team_name,
                     _team_key=team_key,
                 )
+
+            if team_name and team_name in self.team_colour_by_name:
+                result.team_colour = self.team_colour_by_name[team_name]
 
             if "CurrentPosition" in data and data["CurrentPosition"] > 0:
                 result.position_start = data["CurrentPosition"]


### PR DESCRIPTION
## Summary

Resolves #374 

Adds `team_colour` (hex string, e.g. `FF8000`) to the `/v1/championship_teams` endpoint, consistent with the existing format in `/v1/drivers`.

`ChampionshipPrediction` doesn't carry colour data, so this is derived from `DriverList` (the same source used by `/v1/drivers`). The collection now subscribes to both topics and builds a `team_name → team_colour` lookup as `DriverList` messages arrive. A back-fill step handles the case where `ChampionshipPrediction` is processed first (which happens in historical data due to alphabetical topic ordering).

**Verified:** `TeamColour` is present in `DriverList` for tested sessions (e.g. session 9574), with values like `FF8000`, `E80020`, `3671C6`.

## Test plan

- [ ] `ruff` — no new errors in changed file
- [ ] `black` — file unchanged
- [ ] Run `get-processed-documents` for a session and confirm `team_colour` is populated for all teams